### PR TITLE
Fix issue 4 for Probability_of_failure calculation

### DIFF
--- a/reliability/Distributions.py
+++ b/reliability/Distributions.py
@@ -139,6 +139,12 @@ class Weibull_Distribution:
         self.b5 = ss.weibull_min.ppf(0.05, self.beta, scale=self.alpha, loc=self.gamma)
         self.b95 = ss.weibull_min.ppf(0.95, self.beta, scale=self.alpha, loc=self.gamma)
 
+    def _cdf(self, X):
+        return ss.weibull_min.cdf(X, self.beta, scale=self.alpha, loc=self.gamma)
+    
+    def _pdf(self, X):
+        return ss.weibull_min.pdf(X, self.beta, scale=self.alpha, loc=self.gamma)
+    
     def plot(self, xvals=None, xmin=None, xmax=None):
         '''
         Plots all functions (PDF, CDF, SF, HF, CHF) and descriptive statistics in a single figure
@@ -522,6 +528,12 @@ class Normal_Distribution:
         self.param_title_long = str('Normal Distribution (μ=' + str(self.mu) + ',σ=' + str(self.sigma) + ')')
         self.b5 = ss.norm.ppf(0.05, loc=self.mu, scale=self.sigma)
         self.b95 = ss.norm.ppf(0.95, loc=self.mu, scale=self.sigma)
+
+    def _cdf(self, X):
+        return ss.norm.cdf(X, self.mu, self.sigma)
+    
+    def _pdf(self, X):
+        return ss.norm.pdf(X, self.mu, self.sigma)
 
     def plot(self, xvals=None, xmin=None, xmax=None):
         '''
@@ -913,6 +925,12 @@ class Lognormal_Distribution:
         self.b5 = ss.lognorm.ppf(0.05, self.sigma, self.gamma, np.exp(self.mu))  # note that scipy uses mu in a log way compared to most other software, so we must take the exp of the input
         self.b95 = ss.lognorm.ppf(0.95, self.sigma, self.gamma, np.exp(self.mu))
 
+    def _cdf(self, X):
+        return ss.lognorm.cdf(X, self.sigma, self.gamma, np.exp(self.mu))
+    
+    def _pdf(self, X):
+        return ss.lognorm.pdf(X, self.sigma, self.gamma, np.exp(self.mu))
+    
     def plot(self, xvals=None, xmin=None, xmax=None):
         '''
         Plots all functions (PDF, CDF, SF, HF, CHF) and descriptive statistics in a single figure
@@ -1303,6 +1321,12 @@ class Exponential_Distribution:
         self.b5 = ss.expon.ppf(0.05, scale=1 / self.Lambda, loc=self.gamma)
         self.b95 = ss.expon.ppf(0.95, scale=1 / self.Lambda, loc=self.gamma)
 
+    def _cdf(self, X):
+        return ss.expon.cdf(X, scale=1 / self.Lambda, loc=self.gamma)
+    
+    def _pdf(self, X):
+        return ss.expon.pdf(X, scale=1 / self.Lambda, loc=self.gamma)
+    
     def plot(self, xvals=None, xmin=None, xmax=None):
         '''
         Plots all functions (PDF, CDF, SF, HF, CHF) and descriptive statistics in a single figure
@@ -1699,6 +1723,12 @@ class Gamma_Distribution:
         self.b5 = ss.gamma.ppf(0.05, self.beta, scale=self.alpha, loc=self.gamma)
         self.b95 = ss.gamma.ppf(0.95, self.beta, scale=self.alpha, loc=self.gamma)
 
+    def _cdf(self, X):
+        return ss.gamma.cdf(X, self.beta, scale=self.alpha, loc=self.gamma)
+    
+    def _pdf(self, X):
+        return ss.gamma.pdf(X, self.beta, scale=self.alpha, loc=self.gamma)
+    
     def plot(self, xvals=None, xmin=None, xmax=None):
         '''
         Plots all functions (PDF, CDF, SF, HF, CHF) and descriptive statistics in a single figure
@@ -2087,6 +2117,12 @@ class Beta_Distribution:
         self.b5 = ss.beta.ppf(0.05, self.alpha, self.beta, 0, 1)
         self.b95 = ss.beta.ppf(0.95, self.alpha, self.beta, 0, 1)
 
+    def _cdf(self, X):
+        return ss.beta.cdf(X, self.alpha, self.beta, 0, 1)
+    
+    def _pdf(self, X):
+        return ss.beta.pdf(X, self.alpha, self.beta, 0, 1)
+    
     def plot(self, xvals=None, xmin=None, xmax=None):
         '''
         Plots all functions (PDF, CDF, SF, HF, CHF) and descriptive statistics in a single figure

--- a/reliability/Stress_strength.py
+++ b/reliability/Stress_strength.py
@@ -52,18 +52,15 @@ class Probability_of_failure:
             print('If strength and stress are both Normal distributions, it is more accurate to use the exact formula rather than monte carlo estimation. The exact formula is supported in the function Probability_of_failure_normdist')
         
         # calculate the probability of failure
-        def func(x):
-            fail = stress._pdf(x)
-            power = strength._cdf(x)
-            return fail * power
+        func = lambda x: stress._pdf(x) * strength._cdf(x)
         
         # integral transformation [0.0 ; inf] --> [0.0; 1.0]
         integrant = lambda t: func(t / (1.0 - t)) / ((1.0 - t)*(1.0 - t))
         
-        # integrate 
+        # integrate
         self.prob_of_failure = integrate.quad(              \
             integrant, 0.0, 1.0,                            \
-            epsabs=1.0e-11, epsrel=1.0e-11, limit=100       \
+            epsabs=1.0e-4, epsrel=1.0e-6, limit=100         \
         )[0]
         
         if show_distribution_plot is True:

--- a/reliability/Stress_strength.py
+++ b/reliability/Stress_strength.py
@@ -41,7 +41,7 @@ class Probability_of_failure:
     Probability_of_failure(stress=stress, strength=strength, monte_carlo_trials=1000000)
 
     '''
-
+    
     def __init__(self, stress, strength,
                  show_distribution_plot=True,
                  print_results=True,
@@ -50,7 +50,7 @@ class Probability_of_failure:
             raise ValueError('Stress and Strength must both be probability distributions. First define the distribution using Reliability.Distributions.___')
         if type(stress) == Normal_Distribution and type(strength) == Normal_Distribution and warn is True:  # supress the warning by setting warn=False
             print('If strength and stress are both Normal distributions, it is more accurate to use the exact formula rather than monte carlo estimation. The exact formula is supported in the function Probability_of_failure_normdist')
-
+        
         # calculate the probability of failure
         def func(x):
             fail = stress._pdf(x)
@@ -65,7 +65,7 @@ class Probability_of_failure:
             integrant, 0.0, 1.0,                            \
             epsabs=1.0e-11, epsrel=1.0e-11, limit=100       \
         )[0]
-
+        
         if show_distribution_plot is True:
             xmin = stress.b5
             xmax = strength.b95
@@ -87,10 +87,10 @@ class Probability_of_failure:
             plt.title('Stress - Strength Interference Plot')
             plt.xlabel('Probability Density')
             plt.ylabel('Stress and Strength Units')
-
+        
         if print_results is True:
             print('Probability of failure:', self.prob_of_failure)
-
+        
         if show_distribution_plot is True:
             plt.show()
 
@@ -110,22 +110,22 @@ class Probability_of_failure_normdist:
     returns:
     prob_of_failure - the probability of failure
     '''
-
+    
     def __init__(self, stress=None, strength=None, show_distribution_plot=True, print_results=True):
         if type(stress) is not Normal_Distribution:
             raise ValueError('Both stress and strength must be a Normal_Distribution. If you need another distribution then use Probability_of_failure rather than Probability_of_failure_normdist')
         if type(strength) is not Normal_Distribution:
             raise ValueError('Both stress and strength must be a Normal_Distribution. If you need another distribution then use Probability_of_failure rather than Probability_of_failure_normdist')
-
+        
         sigma_strength = strength.sigma
         mu_strength = strength.mu
         sigma_stress = stress.sigma
         mu_stress = stress.mu
         self.prob_of_failure = ss.norm.cdf(-(mu_strength - mu_stress) / ((sigma_strength ** 2 + sigma_stress ** 2) ** 0.5))
-
+        
         if print_results is True:
             print('Probability of failure:', self.prob_of_failure)
-
+        
         if show_distribution_plot is True:
             xmin = stress.b5
             xmax = strength.b95
@@ -145,4 +145,4 @@ class Probability_of_failure_normdist:
             plt.ylabel('Stress and Strength Units')
             plt.subplots_adjust(left=0.15, right=0.93)
             plt.show()
-    
+        


### PR DESCRIPTION
Based on issue #4 I start to implement an alternative integration (replace the _Monte-Carlo method_) for the calculation of probaility of failure.

The implementation use the python default integration method of Fortran library QUADPACK. 
Keep in mind I'm not in the deep of the library. Please check the changes are influnce discrete distributions.

Key changes:

- Each distribution need the functions **_pdf** and **_cdf** for an single or array value like the scipy.stats distributions are holding.
- Usage of the integration function from the Fortran library QUADPACK

Feel free for discussions and whises.